### PR TITLE
ci fix not to publish on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,6 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
       - "v[0-9]+.[0-9]+.[0-9]+-rc*" # Push events to matching v*, i.e. v1.0-rc1, v20.15.10-rc5
-  release:
-    types: [released]
 
 jobs:
   publish:
@@ -18,7 +16,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "14"
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: if [ ! -x "$(command -v yarn)" ]; then npm install -g yarn; fi
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [\#73](https://github.com/Finschia/finschia-js/pull/73) fix the local unit test error
 - [\#88](https://github.com/Finschia/finschia-js/pull/88) apply changed event in finschia v1.0.0-rc6 to pass tests
+- [\#91](https://github.com/Finschia/finschia-js/pull/91) ci fix not to pusblish on release
 
 ### Security
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently auto publish workflow runs on every `tag push` and `release`.
This makes error because same version will be publish to NPM twice.
I fix ci only run on `tag push` and does not run on `release`.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a relevant changelog to `CHANGELOG.md`.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
