### PR TITLE
delete redundant download in workflow

### DIFF
--- a/.github/workflows/finschia-test.yml
+++ b/.github/workflows/finschia-test.yml
@@ -14,11 +14,8 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
-
-      - name: download contracts
-        run: |
-          cd scripts/finschia/contracts
-          bash download.sh
+        with:
+          lfs: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- [\#95](https://github.com/Finschia/finschia-js/pull/95) delete redundant download in workflow
+
 ### Fixed
 
 ### Security


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As issue #94 wasm files for tests are already downloaded in scripts. So download job in workflow is redundant.
In this PR redundant download job is deleted
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a relevant changelog to `CHANGELOG.md`.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
