### PR TITLE
ci: fix publish ci error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
           registry-url: "https://registry.npmjs.org"
       - run: if [ ! -x "$(command -v yarn)" ]; then npm install -g yarn; fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [\#95](https://github.com/Finschia/finschia-js/pull/95) delete redundant download in workflow
 
 ### Fixed
+- [\#103](https://github.com/Finschia/finschia-js/pull/103) fix publish ci error, bump up node version
 
 ### Security
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* fix publish ci error
The node version of publish ci is low. So the ci error occurred.
I update the node version to `16` via this pr.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/Finschia/finschia-js/actions/runs/5998436803/job/16267851954
```sh
Run yarn cache clean --all
yarn cache v1.22.19
success Cleared cache.
Done in 0.04s.
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
error @noble/hashes@1.3.1: The engine "node" is incompatible with this module. Expected version ">= 16". Got "14.21.3"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
You need to install `act` command for github action test. 
```sh
$ act -j publish --container-architecture linux/amd64
```

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added a relevant changelog to `CHANGELOG.md`.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
